### PR TITLE
Add contact forms with Discord webhook backend

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 3001
+CMD ["node", "dist/index.js"]

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  api:
+    build: .
+    ports:
+      - "3001:3001"
+    env_file: .env
+    restart: unless-stopped

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,616 @@
+{
+  "name": "polskabezglutenu-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "polskabezglutenu-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "@hono/node-server": "^1.13.8",
+        "hono": "^4.6.14"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.11",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "polskabezglutenu-api",
+  "type": "module",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.8",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.11",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/server/src/discord.ts
+++ b/server/src/discord.ts
@@ -1,0 +1,64 @@
+const FIELD_LABELS: Record<string, string> = {
+  nazwa: "Nazwa",
+  kategorie: "Kategorie",
+  miejscowość: "Miejscowość",
+  adres: "Adres",
+  opis: "Opis",
+  www: "Strona internetowa",
+  "tylko-bezglutenowe": "Tylko bezglutenowe",
+  lat: "Szerokość geograficzna",
+  lng: "Długość geograficzna",
+  komentarz: "Komentarz",
+  "typ-problemu": "Typ problemu",
+  "opis-problemu": "Opis problemu",
+  "poprawne-dane": "Poprawne dane",
+  źródło: "Źródło informacji",
+  "dodatkowe-informacje": "Dodatkowe informacje",
+};
+
+type SubmissionType = "new-place" | "data-problem";
+
+const TITLES: Record<SubmissionType, string> = {
+  "new-place": "[Nowe miejsce]",
+  "data-problem": "[Problem z danymi]",
+};
+
+const COLORS: Record<SubmissionType, number> = {
+  "new-place": 0x00d26a,
+  "data-problem": 0xff8c00,
+};
+
+export async function sendToDiscord(
+  webhookUrl: string,
+  fields: Record<string, string>,
+  type: SubmissionType,
+): Promise<void> {
+  const embedFields = Object.entries(fields)
+    .filter(([, value]) => value && value.trim() !== "")
+    .map(([key, value]) => ({
+      name: FIELD_LABELS[key] || key,
+      value: value.length > 1024 ? value.slice(0, 1021) + "..." : value,
+      inline: value.length < 50,
+    }));
+
+  const payload = {
+    embeds: [
+      {
+        title: TITLES[type],
+        color: COLORS[type],
+        fields: embedFields,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  };
+
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Discord webhook failed: ${res.status} ${await res.text()}`);
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,107 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { sendToDiscord } from "./discord.js";
+
+const app = new Hono();
+
+const ALLOWED_ORIGINS = [
+  "https://polskabezglutenu.pl",
+  "http://localhost:4321",
+];
+
+app.use("*", cors({ origin: ALLOWED_ORIGINS }));
+
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+const RATE_LIMIT = 5;
+const RATE_WINDOW = 60_000;
+
+function getIp(c: { req: { header: (n: string) => string | undefined } }): string {
+  return c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+}
+
+function rateLimit(ip: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(ip);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_WINDOW });
+    return false;
+  }
+  entry.count++;
+  return entry.count > RATE_LIMIT;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of rateLimitMap) {
+    if (now > entry.resetAt) rateLimitMap.delete(ip);
+  }
+}, RATE_WINDOW);
+
+const WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+
+if (!WEBHOOK_URL) {
+  console.error("DISCORD_WEBHOOK_URL env var is required");
+  process.exit(1);
+}
+
+app.post("/api/submit-place", async (c) => {
+  const ip = getIp(c);
+  if (rateLimit(ip)) {
+    return c.json({ ok: false, error: "Za dużo zgłoszeń. Spróbuj ponownie za chwilę." }, 429);
+  }
+
+  const body = await c.req.json<Record<string, string>>();
+
+  if (body._hp) {
+    return c.json({ ok: true });
+  }
+
+  const required = ["nazwa", "kategorie", "miejscowość", "adres", "tylko-bezglutenowe"];
+  for (const field of required) {
+    if (!body[field] || body[field].trim() === "") {
+      return c.json({ ok: false, error: `Pole "${field}" jest wymagane.` }, 400);
+    }
+  }
+
+  try {
+    await sendToDiscord(WEBHOOK_URL, body, "new-place");
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error("Discord webhook error:", err);
+    return c.json({ ok: false, error: "Wystąpił błąd. Spróbuj ponownie później." }, 500);
+  }
+});
+
+app.post("/api/report-problem", async (c) => {
+  const ip = getIp(c);
+  if (rateLimit(ip)) {
+    return c.json({ ok: false, error: "Za dużo zgłoszeń. Spróbuj ponownie za chwilę." }, 429);
+  }
+
+  const body = await c.req.json<Record<string, string>>();
+
+  if (body._hp) {
+    return c.json({ ok: true });
+  }
+
+  const required = ["nazwa", "typ-problemu", "opis-problemu"];
+  for (const field of required) {
+    if (!body[field] || body[field].trim() === "") {
+      return c.json({ ok: false, error: `Pole "${field}" jest wymagane.` }, 400);
+    }
+  }
+
+  try {
+    await sendToDiscord(WEBHOOK_URL, body, "data-problem");
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error("Discord webhook error:", err);
+    return c.json({ ok: false, error: "Wystąpił błąd. Spróbuj ponownie później." }, 500);
+  }
+});
+
+const port = parseInt(process.env.PORT ?? "3001", 10);
+serve({ fetch: app.fetch, port }, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/src/components/FooterLinks.tsx
+++ b/src/components/FooterLinks.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { AlertTriangle, MapPin, Mail } from "lucide-react";
+import { SubmitPlaceDialog } from "@/components/SubmitPlaceDialog";
+import { ReportProblemDialog } from "@/components/ReportProblemDialog";
+
+interface FooterLinksProps {
+  variant?: "footer" | "nav";
+}
+
+export function FooterLinks({ variant = "footer" }: FooterLinksProps) {
+  const [submitPlaceOpen, setSubmitPlaceOpen] = useState(false);
+  const [reportProblemOpen, setReportProblemOpen] = useState(false);
+
+  const isNav = variant === "nav";
+
+  return (
+    <>
+      <div className={isNav ? "flex items-center gap-4" : "flex flex-col md:flex-row gap-4 justify-center"}>
+        <button
+          onClick={() => setReportProblemOpen(true)}
+          className="hover:text-primary hover:underline inline-flex items-center gap-1"
+        >
+          {isNav && <AlertTriangle size={14} />}
+          Zgłoś problem z danymi
+        </button>
+        <button
+          onClick={() => setSubmitPlaceOpen(true)}
+          className="hover:text-primary hover:underline inline-flex items-center gap-1"
+        >
+          {isNav && <MapPin size={14} />}
+          Zgłoś nowe miejsce
+        </button>
+        <a href="mailto:kontakt@polskabezglutenu.pl" className="hover:text-primary hover:underline inline-flex items-center gap-1">
+          {isNav && <Mail size={14} />}
+          Kontakt
+        </a>
+      </div>
+
+      <SubmitPlaceDialog open={submitPlaceOpen} onOpenChange={setSubmitPlaceOpen} />
+      <ReportProblemDialog open={reportProblemOpen} onOpenChange={setReportProblemOpen} />
+    </>
+  );
+}

--- a/src/components/ReportProblemDialog.tsx
+++ b/src/components/ReportProblemDialog.tsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { submitForm } from "@/lib/api";
+
+const PROBLEM_TYPES = [
+  "Niepoprawna nazwa",
+  "Niepoprawny opis",
+  "Niepoprawne kategorie",
+  "Niepoprawna miejscowość",
+  "Niepoprawny adres",
+  "Niepoprawna strona internetowa",
+  "Niepoprawna informacja o bezglutenowości",
+  "Niepoprawne współrzędne geograficzne",
+  "Miejsce już nie istnieje",
+  "Miejsce nie oferuje już opcji bezglutenowych",
+  "Inne",
+];
+
+interface ReportProblemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ReportProblemDialog({ open, onOpenChange }: ReportProblemDialogProps) {
+  const [nazwa, setNazwa] = useState("");
+  const [typProblemu, setTypProblemu] = useState<string[]>([]);
+  const [opisProblemu, setOpisProblemu] = useState("");
+  const [poprawneDane, setPoprawneDane] = useState("");
+  const [zrodlo, setZrodlo] = useState("");
+  const [dodatkoweInfo, setDodatkoweInfo] = useState("");
+  const [hp, setHp] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<"idle" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  function toggleProblemType(type: string) {
+    setTypProblemu((prev) =>
+      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type],
+    );
+  }
+
+  function resetForm() {
+    setNazwa("");
+    setTypProblemu([]);
+    setOpisProblemu("");
+    setPoprawneDane("");
+    setZrodlo("");
+    setDodatkoweInfo("");
+    setHp("");
+    setResult("idle");
+    setErrorMsg("");
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrorMsg("");
+
+    const data: Record<string, string> = {
+      nazwa,
+      "typ-problemu": typProblemu.join(", "),
+      "opis-problemu": opisProblemu,
+      "poprawne-dane": poprawneDane,
+      źródło: zrodlo,
+      "dodatkowe-informacje": dodatkoweInfo,
+      _hp: hp,
+    };
+
+    const res = await submitForm("/api/report-problem", data);
+
+    setSubmitting(false);
+    if (res.ok) {
+      setResult("success");
+    } else {
+      setResult("error");
+      setErrorMsg(res.error || "Wystąpił błąd.");
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) resetForm();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Zgłoś problem z danymi</DialogTitle>
+          <DialogDescription>
+            Zgłoś niepoprawne dane miejsca bezglutenowego na mapie.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result === "success" ? (
+          <div className="py-8 text-center">
+            <p className="text-lg font-medium text-green-600">Dziękujemy za zgłoszenie!</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Twoje zgłoszenie zostanie zweryfikowane i dane zostaną zaktualizowane.
+            </p>
+            <Button className="mt-4" onClick={() => onOpenChange(false)}>
+              Zamknij
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="hidden" aria-hidden="true">
+              <input
+                type="text"
+                tabIndex={-1}
+                value={hp}
+                onChange={(e) => setHp(e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="rp-nazwa" className="text-sm font-medium">
+                Nazwa miejsca <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="rp-nazwa"
+                value={nazwa}
+                onChange={(e) => setNazwa(e.target.value)}
+                required
+                placeholder="np. A'Favela"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                Typ problemu <span className="text-destructive">*</span>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {PROBLEM_TYPES.map((type) => (
+                  <Badge
+                    key={type}
+                    variant={typProblemu.includes(type) ? "default" : "outline"}
+                    className="cursor-pointer select-none"
+                    onClick={() => toggleProblemType(type)}
+                  >
+                    {type}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="rp-opis" className="text-sm font-medium">
+                Opis problemu <span className="text-destructive">*</span>
+              </label>
+              <textarea
+                id="rp-opis"
+                value={opisProblemu}
+                onChange={(e) => setOpisProblemu(e.target.value)}
+                required
+                rows={3}
+                className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="Opisz dokładnie, na czym polega problem..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="rp-poprawne" className="text-sm font-medium">
+                Poprawne dane
+              </label>
+              <textarea
+                id="rp-poprawne"
+                value={poprawneDane}
+                onChange={(e) => setPoprawneDane(e.target.value)}
+                rows={2}
+                className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="Podaj poprawne dane, jeśli je znasz..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="rp-zrodlo" className="text-sm font-medium">
+                Źródło informacji
+              </label>
+              <Input
+                id="rp-zrodlo"
+                value={zrodlo}
+                onChange={(e) => setZrodlo(e.target.value)}
+                placeholder="np. byłem/am tam osobiście"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="rp-dodatkowe" className="text-sm font-medium">
+                Dodatkowe informacje
+              </label>
+              <textarea
+                id="rp-dodatkowe"
+                value={dodatkoweInfo}
+                onChange={(e) => setDodatkoweInfo(e.target.value)}
+                rows={2}
+                className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="Dodatkowe uwagi..."
+              />
+            </div>
+
+            {result === "error" && errorMsg && (
+              <p className="text-sm text-destructive">{errorMsg}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={submitting || typProblemu.length === 0}>
+              {submitting ? "Wysyłanie..." : "Wyślij zgłoszenie"}
+            </Button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SubmitPlaceDialog.tsx
+++ b/src/components/SubmitPlaceDialog.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { submitForm } from "@/lib/api";
+
+const CATEGORIES = [
+  "restauracja",
+  "kawiarnia",
+  "piekarnia",
+  "cukiernia",
+  "sklep",
+  "hotel",
+  "inne",
+];
+
+interface SubmitPlaceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SubmitPlaceDialog({ open, onOpenChange }: SubmitPlaceDialogProps) {
+  const [nazwa, setNazwa] = useState("");
+  const [kategorie, setKategorie] = useState<string[]>([]);
+  const [miejscowosc, setMiejscowosc] = useState("");
+  const [adres, setAdres] = useState("");
+  const [tylkoBezglutenowe, setTylkoBezglutenowe] = useState("");
+  const [opis, setOpis] = useState("");
+  const [www, setWww] = useState("");
+  const [lat, setLat] = useState("");
+  const [lng, setLng] = useState("");
+  const [komentarz, setKomentarz] = useState("");
+  const [hp, setHp] = useState("");
+
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<"idle" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  function toggleCategory(cat: string) {
+    setKategorie((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat],
+    );
+  }
+
+  function resetForm() {
+    setNazwa("");
+    setKategorie([]);
+    setMiejscowosc("");
+    setAdres("");
+    setTylkoBezglutenowe("");
+    setOpis("");
+    setWww("");
+    setLat("");
+    setLng("");
+    setKomentarz("");
+    setHp("");
+    setResult("idle");
+    setErrorMsg("");
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrorMsg("");
+
+    const data: Record<string, string> = {
+      nazwa,
+      kategorie: kategorie.join(", "),
+      miejscowość: miejscowosc,
+      adres,
+      "tylko-bezglutenowe": tylkoBezglutenowe,
+      opis,
+      www,
+      lat,
+      lng,
+      komentarz,
+      _hp: hp,
+    };
+
+    const res = await submitForm("/api/submit-place", data);
+
+    setSubmitting(false);
+    if (res.ok) {
+      setResult("success");
+    } else {
+      setResult("error");
+      setErrorMsg(res.error || "Wystąpił błąd.");
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) resetForm();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Zgłoś nowe miejsce</DialogTitle>
+          <DialogDescription>
+            Wypełnij formularz, aby zgłosić nowe miejsce przyjazne osobom na diecie
+            bezglutenowej.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result === "success" ? (
+          <div className="py-8 text-center">
+            <p className="text-lg font-medium text-green-600">Dziękujemy za zgłoszenie!</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Twoje zgłoszenie zostanie zweryfikowane i dodane do mapy.
+            </p>
+            <Button className="mt-4" onClick={() => onOpenChange(false)}>
+              Zamknij
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="hidden" aria-hidden="true">
+              <input
+                type="text"
+                tabIndex={-1}
+                value={hp}
+                onChange={(e) => setHp(e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-nazwa" className="text-sm font-medium">
+                Nazwa <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="sp-nazwa"
+                value={nazwa}
+                onChange={(e) => setNazwa(e.target.value)}
+                required
+                placeholder="np. A'Favela"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                Kategorie <span className="text-destructive">*</span>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {CATEGORIES.map((cat) => (
+                  <Badge
+                    key={cat}
+                    variant={kategorie.includes(cat) ? "default" : "outline"}
+                    className="cursor-pointer select-none"
+                    onClick={() => toggleCategory(cat)}
+                  >
+                    {cat}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-miejscowosc" className="text-sm font-medium">
+                Miejscowość <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="sp-miejscowosc"
+                value={miejscowosc}
+                onChange={(e) => setMiejscowosc(e.target.value)}
+                required
+                placeholder="np. Bydgoszcz"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-adres" className="text-sm font-medium">
+                Adres <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="sp-adres"
+                value={adres}
+                onChange={(e) => setAdres(e.target.value)}
+                required
+                placeholder="np. Plac Wolności 7, Bydgoszcz"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                Tylko bezglutenowe <span className="text-destructive">*</span>
+              </label>
+              <Select value={tylkoBezglutenowe} onValueChange={setTylkoBezglutenowe}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Wybierz..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="tak">Tak</SelectItem>
+                  <SelectItem value="nie">Nie</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-opis" className="text-sm font-medium">
+                Opis
+              </label>
+              <textarea
+                id="sp-opis"
+                value={opis}
+                onChange={(e) => setOpis(e.target.value)}
+                rows={3}
+                className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="Krótki opis miejsca..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-www" className="text-sm font-medium">
+                Strona internetowa
+              </label>
+              <Input
+                id="sp-www"
+                value={www}
+                onChange={(e) => setWww(e.target.value)}
+                placeholder="https://..."
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label htmlFor="sp-lat" className="text-sm font-medium">
+                  Szerokość geogr.
+                </label>
+                <Input
+                  id="sp-lat"
+                  value={lat}
+                  onChange={(e) => setLat(e.target.value)}
+                  placeholder="np. 53.1273"
+                  type="number"
+                  step="any"
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="sp-lng" className="text-sm font-medium">
+                  Długość geogr.
+                </label>
+                <Input
+                  id="sp-lng"
+                  value={lng}
+                  onChange={(e) => setLng(e.target.value)}
+                  placeholder="np. 18.0066"
+                  type="number"
+                  step="any"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="sp-komentarz" className="text-sm font-medium">
+                Dodatkowy komentarz
+              </label>
+              <textarea
+                id="sp-komentarz"
+                value={komentarz}
+                onChange={(e) => setKomentarz(e.target.value)}
+                rows={3}
+                className="flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                placeholder="Dodatkowe informacje..."
+              />
+            </div>
+
+            {result === "error" && errorMsg && (
+              <p className="text-sm text-destructive">{errorMsg}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={submitting || kategorie.length === 0 || !tylkoBezglutenowe}>
+              {submitting ? "Wysyłanie..." : "Wyślij zgłoszenie"}
+            </Button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,17 @@
+const API_URL = import.meta.env.PUBLIC_API_URL || "https://api.polskabezglutenu.pl";
+
+export async function submitForm(
+  endpoint: string,
+  data: Record<string, string>,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${API_URL}${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    return await res.json();
+  } catch {
+    return { ok: false, error: "Nie można połączyć się z serwerem. Spróbuj ponownie później." };
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import '@/styles/globals.css'
 import Layout from '../layouts/Layout.astro';
 import {TabView} from '../components/TabView';
+import {FooterLinks} from '../components/FooterLinks';
 import {loadData} from "../lib/data-loader";
 
 const places = loadData();
@@ -11,6 +12,11 @@ const places = loadData();
         title="Polska Bez Glutenu - Lista Miejsc"
         description="Lista miejsc przyjaznych osobom na diecie bezglutenowej w Polsce. Restauracje, kawiarnie, piekarnie i inne lokale z ofertą bezglutenową."
 >
+    <nav class="border-b bg-muted/50">
+        <div class="container mx-auto px-4 py-2 flex justify-end gap-4 text-sm text-muted-foreground">
+            <FooterLinks client:only="react" variant="nav" />
+        </div>
+    </nav>
     <main class="container mx-auto px-4 py-8 md:px-8">
         <div class="mb-16 flex flex-row flex-wrap items-center md:gap-20 pl-2 justify-center md:justify-start">
             <div class="mb-4 md:mb-0 tracking-tight text-foreground">
@@ -30,13 +36,6 @@ const places = loadData();
         </div>
     </main>
     <footer class="container mx-auto px-4 py-6 border-t mt-8">
-        <div class="flex flex-col md:flex-row gap-4 justify-center text-sm text-muted-foreground">
-            <a href="https://github.com/aetas/polskabezglutenu/issues/new?template=data-problem.yml" target="_blank" class="hover:text-primary hover:underline">
-                Zgłoś problem z danymi
-            </a>
-            <a href="https://github.com/aetas/polskabezglutenu/issues/new?template=new-place.yml" target="_blank" class="hover:text-primary hover:underline">
-                Zgłoś nowe miejsce
-            </a>
-        </div>
+        <FooterLinks client:only="react" />
     </footer>
 </Layout>


### PR DESCRIPTION
## Summary

- Replace GitHub Issues links with in-page dialog forms for submitting new places and reporting data problems
- Add Hono API server (`server/`) that forwards form submissions to a Discord webhook, with rate limiting (5 req/min/IP) and honeypot spam protection
- Add top nav bar with contact/action links and lucide icons, plus a `mailto:` contact link
- Footer uses the same `FooterLinks` component (text-only variant)

## New files

- `server/` — Hono API backend (Docker-deployable, configurable via `DISCORD_WEBHOOK_URL` env var)
- `src/components/SubmitPlaceDialog.tsx` — Form dialog matching the existing new-place issue template
- `src/components/ReportProblemDialog.tsx` — Form dialog matching the existing data-problem issue template
- `src/components/FooterLinks.tsx` — Shared component for nav/footer action links
- `src/lib/api.ts` — `submitForm()` helper that POSTs to the API

## Deployment

1. On VPS: `cd server && echo "DISCORD_WEBHOOK_URL=https://..." > .env && docker compose up -d`
2. Add Caddy reverse proxy: `api.polskabezglutenu.pl { reverse_proxy localhost:3001 }`
3. Set `PUBLIC_API_URL=https://api.polskabezglutenu.pl` in Astro env vars
4. Rebuild and deploy frontend to GitHub Pages