### PR TITLE
Harden form submission against injection attacks

### DIFF
--- a/server/src/discord.ts
+++ b/server/src/discord.ts
@@ -34,12 +34,29 @@ export async function sendToDiscord(
   type: SubmissionType,
 ): Promise<void> {
   const embedFields = Object.entries(fields)
+    .filter(([key]) => key in FIELD_LABELS)
     .filter(([, value]) => value && value.trim() !== "")
+    .slice(0, 25)
     .map(([key, value]) => ({
-      name: FIELD_LABELS[key] || key,
+      name: FIELD_LABELS[key].slice(0, 256),
       value: value.length > 1024 ? value.slice(0, 1021) + "..." : value,
       inline: value.length < 50,
     }));
+
+  const totalLength = embedFields.reduce(
+    (sum, f) => sum + f.name.length + f.value.length,
+    0,
+  );
+  if (totalLength > 6000) {
+    while (embedFields.length > 1) {
+      embedFields.pop();
+      const newTotal = embedFields.reduce(
+        (sum, f) => sum + f.name.length + f.value.length,
+        0,
+      );
+      if (newTotal <= 6000) break;
+    }
+  }
 
   const payload = {
     embeds: [

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { sendToDiscord } from "./discord.js";
@@ -11,6 +10,88 @@ const ALLOWED_ORIGINS = [
 ];
 
 app.use("*", cors({ origin: ALLOWED_ORIGINS }));
+
+const MAX_BODY_SIZE = 10 * 1024;
+
+const SUBMIT_PLACE_FIELDS = [
+  "nazwa",
+  "kategorie",
+  "miejscowość",
+  "adres",
+  "tylko-bezglutenowe",
+  "opis",
+  "www",
+  "lat",
+  "lng",
+  "komentarz",
+] as const;
+
+const SUBMIT_PLACE_REQUIRED = ["nazwa", "kategorie", "miejscowość", "adres", "tylko-bezglutenowe"];
+
+const REPORT_PROBLEM_FIELDS = [
+  "nazwa",
+  "typ-problemu",
+  "opis-problemu",
+  "poprawne-dane",
+  "źródło",
+  "dodatkowe-informacje",
+] as const;
+
+const REPORT_PROBLEM_REQUIRED = ["nazwa", "typ-problemu", "opis-problemu"];
+
+const MAX_FIELD_LENGTH: Record<string, number> = {
+  nazwa: 256,
+  kategorie: 256,
+  miejscowość: 128,
+  adres: 256,
+  "tylko-bezglutenowe": 16,
+  opis: 1024,
+  www: 512,
+  lat: 32,
+  lng: 32,
+  komentarz: 1024,
+  "typ-problemu": 256,
+  "opis-problemu": 1024,
+  "poprawne-dane": 1024,
+  źródło: 256,
+  "dodatkowe-informacje": 1024,
+};
+
+function sanitizeValue(value: string): string {
+  let sanitized = value
+    .replace(/@everyone/gi, "")
+    .replace(/@here/gi, "")
+    .replace(/<@&?\d+>/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+  return sanitized;
+}
+
+function filterFields(
+  body: Record<string, unknown>,
+  allowed: readonly string[],
+  required: string[],
+): { ok: true; data: Record<string, string> } | { ok: false; error: string } {
+  const data: Record<string, string> = {};
+
+  for (const field of allowed) {
+    const value = body[field];
+    if (value !== undefined && value !== null) {
+      if (typeof value !== "string") {
+        return { ok: false, error: `Pole "${field}" ma niepoprawny format.` };
+      }
+      const maxLen = MAX_FIELD_LENGTH[field] ?? 256;
+      data[field] = sanitizeValue(value).slice(0, maxLen);
+    }
+  }
+
+  for (const field of required) {
+    if (!data[field] || data[field].trim() === "") {
+      return { ok: false, error: `Pole "${field}" jest wymagane.` };
+    }
+  }
+
+  return { ok: true, data };
+}
 
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT = 5;
@@ -51,21 +132,28 @@ app.post("/api/submit-place", async (c) => {
     return c.json({ ok: false, error: "Za dużo zgłoszeń. Spróbuj ponownie za chwilę." }, 429);
   }
 
-  const body = await c.req.json<Record<string, string>>();
+  let body: Record<string, unknown>;
+  try {
+    const raw = await c.req.arrayBuffer();
+    if (raw.byteLength > MAX_BODY_SIZE) {
+      return c.json({ ok: false, error: "Zgłoszenie jest za duże." }, 413);
+    }
+    body = JSON.parse(Buffer.from(raw).toString()) as Record<string, unknown>;
+  } catch {
+    return c.json({ ok: false, error: "Niepoprawne dane." }, 400);
+  }
 
-  if (body._hp) {
+  if (body._hp && typeof body._hp === "string" && body._hp.trim() !== "") {
     return c.json({ ok: true });
   }
 
-  const required = ["nazwa", "kategorie", "miejscowość", "adres", "tylko-bezglutenowe"];
-  for (const field of required) {
-    if (!body[field] || body[field].trim() === "") {
-      return c.json({ ok: false, error: `Pole "${field}" jest wymagane.` }, 400);
-    }
+  const result = filterFields(body, SUBMIT_PLACE_FIELDS, SUBMIT_PLACE_REQUIRED);
+  if (!result.ok) {
+    return c.json({ ok: false, error: result.error }, 400);
   }
 
   try {
-    await sendToDiscord(WEBHOOK_URL, body, "new-place");
+    await sendToDiscord(WEBHOOK_URL, result.data, "new-place");
     return c.json({ ok: true });
   } catch (err) {
     console.error("Discord webhook error:", err);
@@ -79,21 +167,28 @@ app.post("/api/report-problem", async (c) => {
     return c.json({ ok: false, error: "Za dużo zgłoszeń. Spróbuj ponownie za chwilę." }, 429);
   }
 
-  const body = await c.req.json<Record<string, string>>();
+  let body: Record<string, unknown>;
+  try {
+    const raw = await c.req.arrayBuffer();
+    if (raw.byteLength > MAX_BODY_SIZE) {
+      return c.json({ ok: false, error: "Zgłoszenie jest za duże." }, 413);
+    }
+    body = JSON.parse(Buffer.from(raw).toString()) as Record<string, unknown>;
+  } catch {
+    return c.json({ ok: false, error: "Niepoprawne dane." }, 400);
+  }
 
-  if (body._hp) {
+  if (body._hp && typeof body._hp === "string" && body._hp.trim() !== "") {
     return c.json({ ok: true });
   }
 
-  const required = ["nazwa", "typ-problemu", "opis-problemu"];
-  for (const field of required) {
-    if (!body[field] || body[field].trim() === "") {
-      return c.json({ ok: false, error: `Pole "${field}" jest wymagane.` }, 400);
-    }
+  const result = filterFields(body, REPORT_PROBLEM_FIELDS, REPORT_PROBLEM_REQUIRED);
+  if (!result.ok) {
+    return c.json({ ok: false, error: result.error }, 400);
   }
 
   try {
-    await sendToDiscord(WEBHOOK_URL, body, "data-problem");
+    await sendToDiscord(WEBHOOK_URL, result.data, "data-problem");
     return c.json({ ok: true });
   } catch (err) {
     console.error("Discord webhook error:", err);
@@ -101,6 +196,7 @@ app.post("/api/report-problem", async (c) => {
   }
 });
 
+import { serve } from "@hono/node-server";
 const port = parseInt(process.env.PORT ?? "3001", 10);
 serve({ fetch: app.fetch, port }, () => {
   console.log(`Server running on port ${port}`);


### PR DESCRIPTION
## Summary

Security hardening for the contact form API backend, addressing injection and abuse vectors.

### Server (`server/src/index.ts`)
- **Field allowlisting** — only known fields are extracted from the request body; unknown keys are silently dropped
- **Type validation** — all field values must be strings; non-string types are rejected with 400
- **Max body size** — 10KB limit on raw request body (413 if exceeded)
- **Per-field length limits** — each field has a capped max length (e.g. `nazwa: 256`, `opis: 1024`); values are truncated server-side
- **Discord mention sanitization** — `@everyone`, `@here`, and `<@&123>` mention patterns are stripped from values
- **Discord markdown link sanitization** — `[text](url)` patterns are reduced to just the text
- **Honeypot hardening** — only triggers when `_hp` is a non-empty string

### Discord (`server/src/discord.ts`)
- **Field name allowlisting** — only fields in `FIELD_LABELS` are included in the embed payload
- **25-field limit** — Discord embeds cap at 25 fields; extras are sliced off
- **6000-char total limit** — if all fields combined exceed Discord's 6000-char embed limit, trailing fields are trimmed
- **Field name truncation** — embed field names capped at 256 chars