### PR TITLE
Dodaj skilla do dodawania nowych miejsc bezglutenowych

### DIFF
--- a/.agents/skills/add-gf-place/SKILL.md
+++ b/.agents/skills/add-gf-place/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: add-gf-place
+description: Add a new gluten-free place to the polskabezglutenu.pl catalogue. Trigger when user asks to add/dodać a new place/lokal/miejsce to the project/catalogue, or mentions a specific place name with city and wants it added. Covers searching for the place online, creating the YAML data file, and opening a GitHub PR.
+---
+
+# Add Gluten-Free Place
+
+When the user wants to add a new gluten-free place to the catalogue, follow this workflow.
+
+## Workflow
+
+### 1. Search for the place online
+
+Search for the place on Polish gluten-free resources:
+
+- **menubezglutenu.pl** — official MENU BEZ GLUTENU directory (search: `{name} {city} menubezglutenu`)
+- **celiakia.pl** — Polish Coeliac Society news (search: `{name} {city} celiakia`)
+- **DuckDuckGo** — general search (search: `{name} {city} bezglutenowa`)
+- **Facebook** — business page (search: `{name} {city} Facebook`)
+
+From these sources extract:
+- Official name (`nazwa`)
+- Address with street and city (`adres`, `miejscowość`)
+- Website or Facebook page (`www`)
+- Whether it's 100% gluten-free (`tylko-bezglutenowe`: `tak`/`nie`)
+- What type of place it is (for `kategorie`)
+
+If a place is in the MENU BEZ GLUTENU program → `tylko-bezglutenowe: tak` is almost certain.
+
+### 2. Determine categories
+
+Pick from the valid set: `restauracja`, `kawiarnia`, `piekarnia`, `cukiernia`, `sklep`, `hotel`, `inne`.
+
+Use only categories clearly supported by the sources. Do not guess. If the place is a bakery that also sells sweets, `piekarnia` alone is fine unless the source explicitly calls it a `cukiernia` too.
+
+### 3. Determine filename
+
+See `references/schema.md` for full naming rules. Quick rules:
+
+- Lowercase the name, replace spaces with hyphens
+- Preserve Polish diacritics (`ą`, `ć`, `ś`, `ż`, `ó`, `ł`, `ń`, `ź`)
+- For single-location places: `{name-slug}.yaml`
+- For chains with branches: include city, e.g. `{chain}-{city}.yaml`
+
+### 4. Geocode the address
+
+Use Nominatim to get lat/lng:
+```
+https://nominatim.openstreetmap.org/search?q={address}+{city}&format=json&limit=1
+```
+
+Round lat/lng to 7 decimal places (matching existing entries).
+
+### 5. Create the YAML file
+
+Write the file to `dane/{filename}.yaml`. See `references/schema.md` for the full schema and examples.
+
+### 6. Create a PR
+
+- Create a branch: `add/{name-slug}`
+- Commit with message: `Nowe miejsce: {name}`
+- Push and create PR with title: `Nowe miejsce: {name}`
+- PR body: brief summary (what, where, GF-only status, MENU BEZ GLUTENU membership if applicable)

--- a/.agents/skills/add-gf-place/references/schema.md
+++ b/.agents/skills/add-gf-place/references/schema.md
@@ -1,0 +1,75 @@
+# Place YAML Schema
+
+Each place is a YAML file in `dane/`. Fields read by `src/lib/data-loader.ts` and typed by `src/api/types.ts`.
+
+## Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `nazwa` | string | yes | Place name |
+| `opis` | string | yes | Description (always `''` in practice) |
+| `kategorie` | list | yes | One or more of: `restauracja`, `kawiarnia`, `piekarnia`, `cukiernia`, `sklep`, `hotel`, `inne` |
+| `miejscowość` | string | yes | City name |
+| `adres` | string | yes | Full address with street and city |
+| `www` | string | no | Website URL (can be empty string) |
+| `tylko-bezglutenowe` | string | yes | `tak` or `nie` |
+| `lat` | number | no | Latitude |
+| `lng` | number | no | Longitude |
+
+## Filename rules
+
+- Lowercase, spaces → hyphens, preserve Polish diacritics
+- Single-location: `{name-slug}.yaml` (e.g. `placek.yaml`)
+- Chain with branch: `{chain}-{city}.yaml` (e.g. `fit-cake-katowice-śródmieście.yaml`)
+- Em dashes preserved verbatim in filename (e.g. `wolna-–piekarnia-bezglutenowa-opole.yaml`)
+
+## Examples
+
+### 100% GF restaurant
+```yaml
+nazwa: Placek
+opis: ''
+kategorie:
+  - restauracja
+miejscowość: Katowice
+adres: ul. Dworcowa 8, Katowice
+www: http://www.placek.katowice.pl/
+tylko-bezglutenowe: tak
+lat: 50.2572987
+lng: 19.022582
+```
+
+### 100% GF bakery chain branch
+```yaml
+nazwa: WOLNA – piekarnia bezglutenowa Katowice
+opis: ''
+kategorie:
+  - piekarnia
+miejscowość: Katowice
+adres: ul. Plebiscytowa 24, Katowice
+www: https://piekarniawolna.pl/
+tylko-bezglutenowe: tak
+lat: 50.2534065
+lng: 19.0205897
+```
+
+### Non-GF-exclusive place
+```yaml
+nazwa: A'Favela
+opis: ''
+kategorie:
+  - restauracja
+miejscowość: Bydgoszcz
+adres: Plac Wolności 7, Bydgoszcz
+www: https://afavela.pl/restaurants/afavela
+tylko-bezglutenowe: nie
+lat: 53.1273286
+lng: 18.0066158
+```
+
+## Commit & PR conventions
+
+- Branch: `add/{name-slug}`
+- Commit message: `Nowe miejsce: {nazwa}`
+- PR title: `Nowe miejsce: {nazwa}`
+- PR body: 1-line summary with address, categories, GF-only status


### PR DESCRIPTION
## Summary
- Added a project-level skill (`.agents/skills/add-gf-place/`) for automating the workflow of adding new gluten-free places
- Covers: searching online sources, extracting place data, geocoding, creating YAML, and opening a PR
- Includes reference file with YAML schema, naming conventions, and examples