### PR TITLE
Nowe miejsca: WOLNA Gliwice, Swarzędz, Leszno, Jeżyce (Poznań)

### DIFF
--- a/dane/wolna-na-jeżycach-–piekarnia-bezglutenowa-poznań.yaml
+++ b/dane/wolna-na-jeżycach-–piekarnia-bezglutenowa-poznań.yaml
@@ -1,0 +1,11 @@
+nazwa: WOLNA na Jeżycach – piekarnia bezglutenowa – Poznań
+opis: ''
+kategorie:
+  - piekarnia
+  - cukiernia
+miejscowość: Poznań
+adres: ul. Kraszewskiego 14, Poznań
+www: https://piekarniawolna.pl/
+tylko-bezglutenowe: tak
+lat: 52.4104206
+lng: 16.9030377

--- a/dane/wolna-–piekarnia-bezglutenowa-–gliwice.yaml
+++ b/dane/wolna-–piekarnia-bezglutenowa-–gliwice.yaml
@@ -1,0 +1,11 @@
+nazwa: WOLNA – piekarnia bezglutenowa – Gliwice
+opis: ''
+kategorie:
+  - piekarnia
+  - cukiernia
+miejscowość: Gliwice
+adres: ul. Dworcowa 47, Gliwice
+www: https://piekarniawolna.pl/
+tylko-bezglutenowe: tak
+lat: 50.2965417
+lng: 18.6743170

--- a/dane/wolna-–piekarnia-bezglutenowa-–leszno.yaml
+++ b/dane/wolna-–piekarnia-bezglutenowa-–leszno.yaml
@@ -1,0 +1,11 @@
+nazwa: WOLNA – piekarnia bezglutenowa – Leszno
+opis: ''
+kategorie:
+  - piekarnia
+  - cukiernia
+miejscowość: Leszno
+adres: ul. Bolesława Chrobrego 4, Leszno
+www: https://piekarniawolna.pl/
+tylko-bezglutenowe: tak
+lat: 51.8439250
+lng: 16.5766062

--- a/dane/wolna-–piekarnia-bezglutenowa-–swarzędz.yaml
+++ b/dane/wolna-–piekarnia-bezglutenowa-–swarzędz.yaml
@@ -1,0 +1,11 @@
+nazwa: WOLNA – piekarnia bezglutenowa – Swarzędz
+opis: ''
+kategorie:
+  - piekarnia
+  - cukiernia
+miejscowość: Swarzędz
+adres: ul. Augusta Cieszkowskiego 20, Swarzędz
+www: https://piekarniawolna.pl/
+tylko-bezglutenowe: tak
+lat: 52.4113000
+lng: 17.0850400


### PR DESCRIPTION
## Summary
- WOLNA – piekarnia bezglutenowa – Gliwice (ul. Dworcowa 47)
- WOLNA – piekarnia bezglutenowa – Swarzędz (ul. Cieszkowskiego 20)
- WOLNA – piekarnia bezglutenowa – Leszno (ul. Chrobrego 4)
- WOLNA na Jeżycach – piekarnia bezglutenowa – Poznań (ul. Kraszewskiego 14)

All 4 are 100% gluten-free bakeries certified in the MENU BEZ GLUTENU program.