### PR TITLE
Poprawka: dodaj kategorię cukiernia do WOLNA Katowice

### DIFF
--- a/dane/wolna-–piekarnia-bezglutenowa-katowice.yaml
+++ b/dane/wolna-–piekarnia-bezglutenowa-katowice.yaml
@@ -3,6 +3,7 @@ opis: ''
 kategorie:
   - piekarnia
   - cukiernia
+  - cukiernia
 miejscowość: Katowice
 adres: ul. Plebiscytowa 24, Katowice
 www: https://piekarniawolna.pl/


### PR DESCRIPTION
Dodaję brakującą kategorię `cukiernia` do WOLNA Katowice, dla spójności z pozostałymi lokalizacjami sieci.