### PR TITLE
Nowe miejsce: Piwniczka u Jerzego Waśkowskiego

### DIFF
--- a/dane/piwniczka-u-jerzego-waśkowskiego.yaml
+++ b/dane/piwniczka-u-jerzego-waśkowskiego.yaml
@@ -1,0 +1,10 @@
+nazwa: Piwniczka u Jerzego Waśkowskiego
+opis: ''
+kategorie:
+  - restauracja
+miejscowość: Karwia
+adres: ul. Mikołaja Kopernika 23, Karwia
+www: https://piwniczka-waskowski.pl
+tylko-bezglutenowe: nie
+lat: 54.8281425
+lng: 18.2105222


### PR DESCRIPTION
Restauracja w Karwi (ul. Mikołaja Kopernika 23). Oferuje kuchnię polską i kaszubską oraz catering. Nie jest w 100% bezglutenowa.